### PR TITLE
Add mechanism to close a group and broadcast without timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Broadcasting on a set of channels in Go. Go channels offer different usage patte
 This library solves the problem in direct way. Each routine keeps member structure with own input channel and single for all
 members output channel. Central dispatcher accepts broadcasts and resend them to all members.
 
-Usage [![Go Walker](http://img.shields.io/badge/docs-API-brightgreen.svg?style=flat)](http://gowalker.org/github.com/grafov/bcast)
+Usage [![Go Walker](http://img.shields.io/badge/docs-API-brightgreen.svg?style=flat)](http://gowalker.org/github.com/NimbleIndustry/bcast)
 -----
 
 Firstly import package and create broadcast group. You may create any number of groups for different broadcasts:
 
 			import (
-				"github.com/grafov/bcast"
+				"github.com/NimbleIndustry/bcast"
 			)
 
 			group := bcast.NewGroup() // create broadcast group
@@ -49,7 +49,7 @@ See more examples in a test suit `bcast_test.go`.
 Install
 -------
 
-`go get github.com/grafov/bcast`
+`go get github.com/NimbleIndustry/bcast`
 
 No external dependencies beside standard packages.
 


### PR DESCRIPTION
- Add mechanism to close a Group via Group.Close()
- Add alternative broadcasting mechanism (Group.ContinuousBroadcasting) that doesn’t evaluate a timeout value (passing 0 to .Broadcasting() results in a tight loop)
- Revert to non-blocking delivery of messages in Broadcasting/ContinuousBroadcasting, the newer technique in commit d3ac99c6e3b7c940f30663f61cf9f43008701edc breaks the unit tests and in-place implementations